### PR TITLE
Add Empty Java class

### DIFF
--- a/src/main/java/com/mapbox/android/sdk/versions/EmptyClass.java
+++ b/src/main/java/com/mapbox/android/sdk/versions/EmptyClass.java
@@ -1,0 +1,9 @@
+package com.mapbox.android.sdk.versions;
+
+/**
+ * Empty java class to prevent empty javadoc.jar so as to make Sonatype happy.
+ * <p>https://github.com/bigdatagenomics/adam/issues/1212
+ * <p>https://central.sonatype.org/pages/requirements.html#supply-javadoc-and-sources
+ */
+public class EmptyClass {
+}


### PR DESCRIPTION
Empty java class is required to create a non empty javadoc.jar artifact
thats required to make Sonatype happy.