### PR TITLE
Fix generateSources artifact

### DIFF
--- a/gradle/mvn-push-plugin.gradle
+++ b/gradle/mvn-push-plugin.gradle
@@ -108,8 +108,10 @@ afterEvaluate { project ->
     }
 
     task generateSourcesJar(type: Jar) {
-        def sources = project.sourceSets.main.allJava
-
+        classifier = 'sources'
+        def sources = project.sourceSets.main.collect{
+            it.allGroovy + it.allJava
+        }
         from sources
     }
 


### PR DESCRIPTION
Include both java and groovy files in `generateSources` artifact.