### PR TITLE
Changes for first stable release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           path: build/libs
           destination: reports
       - store_test_results:
-          path: app/build/test-results
+          path: build/test-results
 
   # ------------------------------------------------------------------------------
   release:

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 # Persist Mapbox SDK Versions
 
 ### About `android-sdk-versions-plugin`
-This plugin persists Mapbox android SDK version information(for every library module) in a file 
+This plugin persists Mapbox android SDK version information in a file 
 at compile time for further access at run time. This plugin also validates the version 
 to be compliant with https://semver.org/ .
-The persisted file is named after applicationId(for e.g. com.mapbox.andorid.core) and the file content
- is in the following format.
+This file is persisted in assets/sdk-versions folder. The persisted file is named after 
+applicationId(for e.g. com.mapbox.andorid.core) and the file contents are in the following format. 
 ```$xslt
 SDK Module Name/Version
 Version Code
@@ -15,8 +15,9 @@ Version Code
 
 This plugin is inspired from https://github.com/google/play-services-plugins/tree/master/oss-licenses-plugin
 
-All android SDK library modules at Mapbox should apply this plugin to facilitate the Telemetry SDK 
-access all Mapbox SDK versions at run time.
+All Mapbox android SDK modules that incorporate the Telemetry SDK and meant to be released 
+as libraries(artifacts) should apply this plugin to facilitate the Telemetry SDK access 
+all Mapbox library versions at run time.
 
 ### Add the Gradle plugin 
 In your root-level build.gradle, make sure you are using the Maven Central Repository and 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-VERSION_NAME=0.1.3-SNAPSHOT
+VERSION_NAME=1.0.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-sdk-versions
 POM_NAME=Mapbox Android SDK Versions
 POM_DESCRIPTION=Mapbox Android SDK Version persistor

--- a/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
+++ b/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
@@ -35,7 +35,7 @@ class PersistSDKVersionInfo implements Plugin<Project> {
                 def outputFile = new File(sdkVersionsDir, variant.applicationId)
                 saveSDKVersionTask.outputFile = outputFile
                 saveSDKVersionTask.sdkVersion = project.version
-                saveSDKVersionTask.sdkVersionCode = variant.generateBuildConfig.versionCode
+                saveSDKVersionTask.sdkVersionCode = variant.generateBuildConfigProvider.get().versionCode
 
                 if (!validateVersion(saveSDKVersionTask.sdkVersion)) {
                     throw new IllegalStateException("Version $saveSDKVersionTask.sdkVersion invalid" +


### PR DESCRIPTION
Bump version to 1.0.0-SNAPSHOT for first stable release.
Update README for clarity.
Replace deprecated API in PersistSDKVersionInfo.groovy.
This change readies this plugin for first stable release.
