### PR TITLE
Update Node version to >=10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-VERSION_NAME=1.0.1-SNAPSHOT
+VERSION_NAME=1.0.2-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-sdk-versions
 POM_NAME=Mapbox Android SDK Versions
 POM_DESCRIPTION=Mapbox Android SDK Version persistor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/android-sdk-versions-plugin",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "description": "Android SDK Versions",
   "keywords": [
     "mapbox",
@@ -15,7 +15,7 @@
     "@mapbox/cloudfriend": "^2.8.2"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Update plugin version in gradle.properties to to 1.0.2-SNAPSHOT.
Node 8 gets to EOL in Dec 2019. It is recommended to update to the latest node version as mentioned here:
https://github.com/mapbox/telemetry/issues/572