### PR TITLE
Update gradle version to the latest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ groovydoc:
 	./gradlew groovydoc
 
 publish:
-	export IS_LOCAL_DEVELOPMENT=false; ./gradlew uploadArchives
+	export IS_LOCAL_DEVELOPMENT=false; ./gradlew publish
 
 publish-local:
 	# This publishes to ~/.m2/repository/com/mapbox/mapboxsdk
-	export IS_LOCAL_DEVELOPMENT=true; ./gradlew uploadArchives
+	export IS_LOCAL_DEVELOPMENT=true; ./gradlew publishToMavenLocal

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
-
 plugins {
-   id 'groovy'
-   id 'jacoco'
+    id 'groovy'
+    id 'jacoco'
 }
 
 group GROUP

--- a/gradle/mvn-push-plugin.gradle
+++ b/gradle/mvn-push-plugin.gradle
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'java'
 
 def isReleaseBuild() {
     return !VERSION_NAME.contains("SNAPSHOT")
@@ -50,96 +51,82 @@ def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
+group = GROUP
+version = VERSION_NAME
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+task groovyDocs(type: Groovydoc) {
+    def sources = project.sourceSets.main.allGroovy
+    source = sources
+    classpath = project.sourceSets.main.output + project.sourceSets.main.compileClasspath
+}
+
+task groovyDocsJar(type: Jar, dependsOn: groovyDocs) {
+    archiveClassifier = 'groovydoc'
+    from groovyDocs.destinationDir
+}
+
 afterEvaluate { project ->
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-                pom.groupId = GROUP
-                pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
-
-                if (isLocalBuild()) {
-                    repository(url: obtainMavenLocalUrl())
-                } else {
-                    repository(url: getReleaseRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                }
-
-                pom.project {
-                    name POM_NAME
-                    packaging POM_PACKAGING
-                    description POM_DESCRIPTION
-                    url POM_URL
-
-                    scm {
-                        url POM_SCM_URL
-                        connection POM_SCM_CONNECTION
-                        developerConnection POM_SCM_DEV_CONNECTION
-                    }
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                artifact(groovyDocsJar)
+                pom {
+                    packaging = POM_PACKAGING
+                    description = POM_DESCRIPTION
+                    url = POM_URL
+                    artifactId = POM_ARTIFACT_ID
 
                     licenses {
                         license {
-                            name POM_LICENCE_NAME
-                            url POM_LICENCE_URL
-                            distribution POM_LICENCE_DIST
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                            distribution = POM_LICENCE_DIST
                         }
                     }
-
                     developers {
                         developer {
-                            id POM_DEVELOPER_ID
-                            name POM_DEVELOPER_NAME
+                            id = POM_DEVELOPER_ID
+                            name = POM_DEVELOPER_NAME
                         }
                     }
+                    scm {
+                        url = POM_SCM_URL
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                // change URLs to point to your repos, e.g. http://my.org/repo
+                def releasesRepoUrl = getReleaseRepositoryUrl()
+                def snapshotsRepoUrl = getSnapshotRepositoryUrl()
+                def localUrl = obtainMavenLocalUrl()
+                url = isLocalBuild() ? localUrl : isReleaseBuild() ? releasesRepoUrl : snapshotsRepoUrl
+                credentials {
+                    username = isLocalBuild() ? "" : getRepositoryUsername()
+                    password = isLocalBuild() ? "" : getRepositoryPassword()
                 }
             }
         }
     }
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("publish") }
+        sign publishing.publications.mavenJava
     }
 
-    task generateSourcesJar(type: Jar) {
-        classifier = 'sources'
-        def sources = project.sourceSets.main.collect{
-            it.allGroovy + it.allJava
+    javadoc {
+        if (JavaVersion.current().isJava9Compatible()) {
+            options.addBooleanOption('html5', true)
         }
-        from sources
-    }
-
-    task groovyDocs(type: Groovydoc) {
-        def sources = project.sourceSets.main.allGroovy
-        source = sources
-        classpath = project.sourceSets.main.output + project.sourceSets.main.compileClasspath
-    }
-
-    task groovyDocsJar(type: Jar, dependsOn: groovyDocs) {
-        classifier = 'groovydoc'
-        from groovyDocs.destinationDir
-    }
-
-    task javaDocs(type: Javadoc) {
-        def sources = project.sourceSets.main.allJava
-        source = sources
-        classpath = project.sourceSets.main.output + project.sourceSets.main.compileClasspath
-    }
-
-    task javaDocsJar(type: Jar, dependsOn: javaDocs) {
-        classifier = 'javadoc'
-        from javaDocs.destinationDir
-    }
-
-    artifacts {
-        archives generateSourcesJar
-        archives javaDocsJar
-        archives groovyDocsJar
     }
 }
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Oct 31 15:29:23 PDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Address removed, changed and deprecated APIs in gradle 6.5:
Update gradle to latest version 6.5.
Fix bug to access the lazy provider(generateBuildConfigProvider.get().versionCode.get()) method via get() method.
Replace deprecated maven plugin with maven-publish plugin.
https://docs.gradle.org/current/userguide/maven_plugin.html
https://docs.gradle.org/current/userguide/publishing_maven.html
