### PR TITLE
Update snapshot version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-VERSION_NAME=1.0.2-SNAPSHOT
+VERSION_NAME=1.1.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-sdk-versions
 POM_NAME=Mapbox Android SDK Versions
 POM_DESCRIPTION=Mapbox Android SDK Version persistor


### PR DESCRIPTION
Update snapshot version to 1.1.0 because there are changes resulting in backward compatible fixes.