### PR TITLE
Fix version code in PersistSDKVersionInfo plugin.

### DIFF
--- a/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
+++ b/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
@@ -35,7 +35,7 @@ class PersistSDKVersionInfo implements Plugin<Project> {
                 def outputFile = new File(sdkVersionsDir, variant.applicationId)
                 saveSDKVersionTask.outputFile = outputFile
                 saveSDKVersionTask.sdkVersion = project.version
-                saveSDKVersionTask.sdkVersionCode = variant.generateBuildConfigProvider.get().versionCode
+                saveSDKVersionTask.sdkVersionCode = variant.generateBuildConfigProvider.get().versionCode.get()
 
                 if (!validateVersion(saveSDKVersionTask.sdkVersion)) {
                     throw new IllegalStateException("Version $saveSDKVersionTask.sdkVersion invalid" +


### PR DESCRIPTION
Access the lazy provider(generateBuildConfigProvider.get().versionCod…e.get()) method via get() method.