### PR TITLE
If `versionCode` is not available return `null`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/android-sdk-versions-plugin",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -169,9 +169,9 @@
       "dev": true
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "object-inspect": {

--- a/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
+++ b/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
@@ -35,7 +35,7 @@ class PersistSDKVersionInfo implements Plugin<Project> {
                 def outputFile = new File(sdkVersionsDir, variant.applicationId)
                 saveSDKVersionTask.outputFile = outputFile
                 saveSDKVersionTask.sdkVersion = project.version
-                saveSDKVersionTask.sdkVersionCode = variant.generateBuildConfigProvider.get().versionCode.get()
+                saveSDKVersionTask.sdkVersionCode = variant.generateBuildConfigProvider.get().versionCode.getOrNull()
 
                 if (!validateVersion(saveSDKVersionTask.sdkVersion)) {
                     throw new IllegalStateException("Version $saveSDKVersionTask.sdkVersion invalid" +


### PR DESCRIPTION
Starting from version `4.1.0` Android Gradle plugin doesn't provide
ability to fetch `versionCode` ([link](https://stackoverflow.com/a/64379691))
For this case we should return `null` and use 0 as default value.

Fix #29

I tested this fix locally by publishing to the local maven repository and building `mapbox-navigation-android` using this version and it seems to build fine.