### PR TITLE
fix outputDir property of clean up task

### DIFF
--- a/src/main/groovy/com/mapbox/android/sdk/versions/SDKVersionCleanUpTask.groovy
+++ b/src/main/groovy/com/mapbox/android/sdk/versions/SDKVersionCleanUpTask.groovy
@@ -1,7 +1,7 @@
 package com.mapbox.android.sdk.versions
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -12,8 +12,8 @@ class SDKVersionCleanUpTask extends DefaultTask {
     /**
      * Output directory set to this task.
      */
-    @Input
-    public File outputDir
+    @OutputDirectory
+    File outputDir
 
     @TaskAction
     void action() {


### PR DESCRIPTION
Fixes #36. Details here: https://docs.gradle.org/7.3.1/userguide/validation_problems.html#ignored_annotations_on_field. 
When we specify a visibility modifier, we get a field instead of a property. But Gradle allows annotations on properties only. 