### PR TITLE
make packageAssets and mergeAssets depend on saveSDKVersion

### DIFF
--- a/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
+++ b/src/main/groovy/com/mapbox/android/sdk/versions/PersistSDKVersionInfo.groovy
@@ -63,6 +63,12 @@ class PersistSDKVersionInfo implements Plugin<Project> {
         def cleanupTask = project.tasks.create("cleanSDKVersions", SDKVersionCleanUpTask)
         cleanupTask.outputDir = sdkVersionsDir
         project.tasks.findByName("clean").dependsOn(cleanupTask)
+
+        project.tasks.matching {
+            (it.name.startsWith("package") || it.name.startsWith("merge")) && it.name.endsWith("Assets")
+        }.configureEach {
+            dependsOn saveSDKVersionTask
+        }
     }
 
     /**


### PR DESCRIPTION
When building with Gradle Wrapper 8.10, without this fix I get an error:

```
Exception is:
org.gradle.internal.execution.WorkValidationException: A problem was found with the configuration of task ':public-api:libnavigation-core:packageDebugAssets' (type 'MergeSourceSetFolders').
  - Gradle detected a problem with the following location: '/Users/dzinadybouskaya/StudioProjects/navigation/projects/mapbox-navigation-android-internal/mapbox-navigation-android/libnavigation-core/src/main/assets'.
    
    Reason: Task ':public-api:libnavigation-core:packageDebugAssets' uses this output of task ':public-api:libnavigation-core:saveSDKVersion' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':public-api:libnavigation-core:saveSDKVersion' as an input of ':public-api:libnavigation-core:packageDebugAssets'.
      2. Declare an explicit dependency on ':public-api:libnavigation-core:saveSDKVersion' from ':public-api:libnavigation-core:packageDebugAssets' using Task#dependsOn.
      3. Declare an explicit dependency on ':public-api:libnavigation-core:saveSDKVersion' from ':public-api:libnavigation-core:packageDebugAssets' using Task#mustRunAfter.
```